### PR TITLE
feat(one-time-keys): first pass at adapting DBCs to one-time-keys

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -5,6 +5,9 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
 
 use curve25519_dalek_ng::scalar::Scalar;
+use core::time::Duration;
+
+
 use sn_dbc::{
     bls_dkg_id, AmountSecrets, Dbc, DbcContent, Error, Mint, ReissueRequest, ReissueTransaction,
     SimpleKeyManager, SimpleSigner, SimpleSpendBook,
@@ -234,5 +237,9 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     });
 }
 
-criterion_group!(reissue, bench_reissue_1_to_100, bench_reissue_100_to_1);
+criterion_group!{
+    name = reissue;
+    config = Criterion::default().measurement_time(Duration::new(20, 0));
+    targets = bench_reissue_1_to_100, bench_reissue_100_to_1
+}
 criterion_main!(reissue);

--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -3,10 +3,9 @@
 use bls_dkg::SecretKeyShare;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
+use std::time::Duration;
 
 use curve25519_dalek_ng::scalar::Scalar;
-use core::time::Duration;
-
 
 use sn_dbc::{
     bls_dkg_id, AmountSecrets, Dbc, DbcContent, Error, Mint, ReissueRequest, ReissueTransaction,
@@ -70,7 +69,7 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
     let n_outputs: u32 = 100;
     let (mut genesis, genesis_owner, genesis_dbc) = genesis(n_outputs as u64);
 
-    let inputs = HashSet::from_iter(vec![genesis_dbc.clone()]);
+    let inputs = HashSet::from_iter([genesis_dbc.clone()]);
     let input_hashes = BTreeSet::from_iter(inputs.iter().map(|in_dbc| in_dbc.name()));
 
     let genesis_secrets = decrypt_amount_secrets(&genesis_owner, &genesis_dbc.content).unwrap();
@@ -105,7 +104,7 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
 
     let reissue = ReissueRequest {
         transaction,
-        input_ownership_proofs: HashMap::from_iter(vec![(
+        input_ownership_proofs: HashMap::from_iter([(
             genesis_dbc.name(),
             (genesis_owner.public_key_set.public_key(), sig),
         )]),
@@ -126,7 +125,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     let n_outputs: u32 = 100;
     let (mut genesis, genesis_owner, genesis_dbc) = genesis(n_outputs as u64);
 
-    let inputs = HashSet::from_iter(vec![genesis_dbc.clone()]);
+    let inputs = HashSet::from_iter([genesis_dbc.clone()]);
     let input_hashes = BTreeSet::from_iter(inputs.iter().map(|in_dbc| in_dbc.name()));
 
     let genesis_secrets = decrypt_amount_secrets(&genesis_owner, &genesis_dbc.content).unwrap();
@@ -171,7 +170,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
 
     let reissue = ReissueRequest {
         transaction,
-        input_ownership_proofs: HashMap::from_iter(vec![(
+        input_ownership_proofs: HashMap::from_iter([(
             genesis_dbc.name(),
             (genesis_owner.public_key_set.public_key(), sig),
         )]),
@@ -189,7 +188,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     let dbcs = Vec::from_iter(outputs.into_iter().map(|content| Dbc {
         content,
         transaction: transaction.clone(),
-        transaction_sigs: BTreeMap::from_iter(vec![(
+        transaction_sigs: BTreeMap::from_iter([(
             genesis_dbc.name(),
             (mint_key_set.public_key(), mint_sig.clone()),
         )]),
@@ -206,7 +205,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
 
     let merge_transaction = ReissueTransaction {
         inputs: HashSet::from_iter(dbcs.clone()),
-        outputs: HashSet::from_iter(vec![merged_output]),
+        outputs: HashSet::from_iter([merged_output]),
     };
 
     let input_ownership_proofs = HashMap::from_iter(dbcs.iter().enumerate().map(|(i, dbc)| {
@@ -237,7 +236,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     });
 }
 
-criterion_group!{
+criterion_group! {
     name = reissue;
     config = Criterion::default().measurement_time(Duration::new(20, 0));
     targets = bench_reissue_1_to_100, bench_reissue_100_to_1

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -247,7 +247,7 @@ fn mk_new_mint(secret_key_set: SecretKeySet, poly: Poly, amount: u64) -> Result<
     let genesis_dbc = Dbc {
         content: genesis_set[0].0.clone(),
         transaction: genesis_set[0].1.clone(),
-        transaction_sigs: BTreeMap::from_iter(vec![(
+        transaction_sigs: BTreeMap::from_iter([(
             sn_dbc::GENESIS_DBC_INPUT,
             (genesis_pubkey, genesis_sig),
         )]),
@@ -1040,7 +1040,7 @@ fn reissue_ez(mintinfo: &mut MintInfo) -> Result<()> {
 
     let reissue_request = ReissueRequest {
         transaction,
-        //        input_ownership_proofs: HashMap::from_iter(vec![(mintinfo.genesis.name(), sig)]),
+        //        input_ownership_proofs: HashMap::from_iter([(mintinfo.genesis.name(), sig)]),
         input_ownership_proofs: proofs,
     };
 

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{
-    DbcContent, DbcContentHash, DbcTransaction, Error, Hash, KeyManager, PublicKey, Result,
-    Signature,
-};
+use crate::{DbcContent, DbcTransaction, Error, KeyManager, PublicKey, Result, Signature};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -63,7 +60,7 @@ mod tests {
 
     use crate::tests::{DbcHelper, NonZeroTinyInt, TinyInt};
     use crate::{
-        KeyManager, Mint, ReissueRequest, ReissueTransaction, SimpleKeyManager, SimpleSigner,
+        Hash, KeyManager, Mint, ReissueRequest, ReissueTransaction, SimpleKeyManager, SimpleSigner,
         SimpleSpendBook,
     };
 
@@ -83,7 +80,7 @@ mod tests {
         n_ways: u8,
         output_owner: &blsttc::PublicKeySet,
     ) -> Result<(ReissueRequest, Scalar), Error> {
-        let inputs = HashSet::from_iter(vec![dbc.clone()]);
+        let inputs = HashSet::from_iter([dbc.clone()]);
         let input_owners = BTreeSet::from_iter(inputs.iter().map(|in_dbc| in_dbc.owner()));
 
         let amount_secrets = DbcHelper::decrypt_amount_secrets(dbc_owner, &dbc.content)?;
@@ -122,7 +119,7 @@ mod tests {
         Ok((
             ReissueRequest {
                 transaction,
-                input_ownership_proofs: HashMap::from_iter(vec![(dbc.owner(), sig)]),
+                input_ownership_proofs: HashMap::from_iter([(dbc.owner(), sig)]),
             },
             outputs_bf_sum,
         ))
@@ -138,7 +135,7 @@ mod tests {
             DbcContent::random_blinding_factor(),
         )?;
 
-        let input_content_owners = BTreeSet::from_iter(vec![input_content.owner]);
+        let input_content_owners = BTreeSet::from_iter([input_content.owner]);
 
         let dbc = Dbc {
             content: input_content,
@@ -199,7 +196,7 @@ mod tests {
         let genesis_dbc = Dbc {
             content: gen_dbc_content,
             transaction: gen_dbc_trans,
-            transaction_sigs: BTreeMap::from_iter(vec![(genesis_key, (mint_key, mint_sig))]),
+            transaction_sigs: BTreeMap::from_iter([(genesis_key, (mint_key, mint_sig))]),
         };
 
         let input_owner = crate::bls_dkg_id();
@@ -249,7 +246,7 @@ mod tests {
             crate::bls_dkg_id().public_key_set.public_key(),
             inputs_bf_sum,
         )?;
-        let outputs = HashSet::from_iter(vec![content]);
+        let outputs = HashSet::from_iter([content]);
 
         let transaction = ReissueTransaction { inputs, outputs };
         let sig_share = input_owner

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -26,28 +26,8 @@ pub(crate) const RANGE_PROOF_BITS: usize = 64; // note: Range Proof max-bits is 
 pub(crate) const RANGE_PROOF_PARTIES: usize = 1; // The maximum number of parties that can produce an aggregated proof
 pub(crate) const MERLIN_TRANSCRIPT_LABEL: &[u8] = b"SN_DBC";
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-pub struct BlindedOwner(Hash);
-
 const AMT_SIZE: usize = 8; // Amount size: 8 bytes (u64)
 const BF_SIZE: usize = 32; // Blinding factor size: 32 bytes (Scalar)
-
-impl BlindedOwner {
-    pub fn new(owner: &PublicKey, parents: &BTreeSet<DbcContentHash>, output_number: u32) -> Self {
-        let mut sha3 = Sha3::v256();
-
-        for parent in parents.iter() {
-            sha3.update(parent);
-        }
-
-        sha3.update(&output_number.to_be_bytes());
-        sha3.update(&owner.to_bytes());
-
-        let mut hash = [0; 32];
-        sha3.finalize(&mut hash);
-        Self(Hash(hash))
-    }
-}
 
 /// Contains amount and Pedersen Commitment blinding factor which
 /// must be kept secret (encrypted) in the DBC.
@@ -108,25 +88,24 @@ impl AmountSecrets {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct DbcContent {
-    pub parents: BTreeSet<DbcContentHash>, // Parent DBC's, acts as a nonce
+    pub parents: BTreeSet<PublicKey>, // Parent DBC's, acts as a nonce
     pub amount_secrets_cipher: Ciphertext,
     pub commitment: CompressedRistretto,
     pub range_proof_bytes: Vec<u8>, // RangeProof::to_bytes() -> (2 lg n + 9) 32-byte elements, where n is # of secret bits, or 64 in our case. Gives 21 32-byte elements.
     pub output_number: u32,
-    pub owner: BlindedOwner,
+    pub owner: PublicKey,
 }
 
 /// Represents the content of a DBC.
 impl DbcContent {
     // Create a new DbcContent for signing.
     pub fn new(
-        parents: BTreeSet<DbcContentHash>,
+        parents: BTreeSet<PublicKey>,
         amount: u64,
         output_number: u32,
-        owner_key: PublicKey,
+        owner: PublicKey,
         blinding_factor: Scalar,
     ) -> Result<Self, Error> {
-        let owner = BlindedOwner::new(&owner_key, &parents, output_number);
         let secret = amount;
 
         let pc_gens = PedersenGens::default();
@@ -145,7 +124,7 @@ impl DbcContent {
             amount,
             blinding_factor,
         };
-        let amount_secrets_cipher = owner_key.encrypt(amount_secrets.to_bytes().as_slice());
+        let amount_secrets_cipher = owner.encrypt(amount_secrets.to_bytes().as_slice());
 
         Ok(DbcContent {
             parents,
@@ -162,25 +141,16 @@ impl DbcContent {
         Scalar::random(&mut csprng)
     }
 
-    pub fn validate_unblinding(&self, owner_key: &PublicKey) -> Result<(), Error> {
-        let blinded = BlindedOwner::new(owner_key, &self.parents, self.output_number);
-        if blinded == self.owner {
-            Ok(())
-        } else {
-            Err(Error::FailedUnblinding)
-        }
-    }
-
     pub fn hash(&self) -> DbcContentHash {
         let mut sha3 = Sha3::v256();
 
         for parent in self.parents.iter() {
-            sha3.update(parent);
+            sha3.update(&parent.to_bytes());
         }
 
         sha3.update(&self.amount_secrets_cipher.to_bytes());
         sha3.update(&self.output_number.to_be_bytes());
-        sha3.update(&self.owner.0);
+        sha3.update(&self.owner.to_bytes());
 
         let mut hash = [0; 32];
         sha3.finalize(&mut hash);

--- a/src/dbc_transaction.rs
+++ b/src/dbc_transaction.rs
@@ -16,23 +16,23 @@ use tiny_keccak::{Hasher, Sha3};
 /// i.e. a Dbc can be stored anywhere, even offline.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct DbcTransaction {
-    pub inputs: BTreeSet<DbcContentHash>,
-    pub outputs: BTreeSet<DbcContentHash>,
+    pub inputs: BTreeSet<blsttc::PublicKey>,
+    pub outputs: BTreeSet<blsttc::PublicKey>,
 }
 
 impl DbcTransaction {
-    pub fn new(inputs: BTreeSet<DbcContentHash>, outputs: BTreeSet<DbcContentHash>) -> Self {
+    pub fn new(inputs: BTreeSet<blsttc::PublicKey>, outputs: BTreeSet<blsttc::PublicKey>) -> Self {
         Self { inputs, outputs }
     }
 
     pub fn hash(&self) -> Hash {
         let mut sha3 = Sha3::v256();
         for input in self.inputs.iter() {
-            sha3.update(input);
+            sha3.update(&input.to_bytes());
         }
 
         for output in self.outputs.iter() {
-            sha3.update(output);
+            sha3.update(&output.to_bytes());
         }
 
         let mut hash = [0; 32];
@@ -53,13 +53,13 @@ mod tests {
     #[quickcheck]
     fn prop_hash_is_independent_of_order(inputs: Vec<u64>, outputs: Vec<u64>) {
         // This test is here to protect us in the case that someone swaps out the BTreeSet for inputs/outputs for something else
-        let input_hashes: Vec<DbcContentHash> = inputs
+        let input_hashes: Vec<blsttc::PublicKey> = inputs
             .iter()
-            .map(|i| Hash(sha3_256(&i.to_be_bytes())))
+            .map(|_| crate::bls_dkg_id().public_key_set.public_key())
             .collect();
-        let output_hashes: Vec<DbcContentHash> = outputs
+        let output_hashes: Vec<blsttc::PublicKey> = outputs
             .iter()
-            .map(|i| Hash(sha3_256(&i.to_be_bytes())))
+            .map(|i| crate::bls_dkg_id().public_key_set.public_key())
             .collect();
 
         let forward_hash = DbcTransaction::new(

--- a/src/dbc_transaction.rs
+++ b/src/dbc_transaction.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{DbcContentHash, Hash};
+use crate::Hash;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use tiny_keccak::{Hasher, Sha3};
@@ -48,8 +48,6 @@ mod tests {
     use super::*;
     use quickcheck_macros::quickcheck;
 
-    use crate::sha3_256;
-
     #[quickcheck]
     fn prop_hash_is_independent_of_order(inputs: Vec<u64>, outputs: Vec<u64>) {
         // This test is here to protect us in the case that someone swaps out the BTreeSet for inputs/outputs for something else
@@ -59,7 +57,7 @@ mod tests {
             .collect();
         let output_hashes: Vec<blsttc::PublicKey> = outputs
             .iter()
-            .map(|i| crate::bls_dkg_id().public_key_set.public_key())
+            .map(|_| crate::bls_dkg_id().public_key_set.public_key())
             .collect();
 
         let forward_hash = DbcTransaction::new(

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,8 +42,7 @@ pub enum Error {
     #[error("DBC already spent in transaction: {transaction:?}")]
     DbcAlreadySpent {
         transaction: crate::DbcTransaction,
-        transaction_sigs:
-            BTreeMap<crate::DbcContentHash, (crate::PublicKeySet, crate::NodeSignature)>,
+        transaction_sigs: BTreeMap<crate::PublicKey, (crate::PublicKeySet, crate::NodeSignature)>,
     },
     #[error("Genesis Input has already been spent in a different transaction")]
     GenesisInputAlreadySpent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,17 +25,14 @@ mod mint;
 
 pub use crate::{
     dbc::Dbc,
-    dbc_content::{AmountSecrets, BlindedOwner, DbcContent},
+    dbc_content::{AmountSecrets, DbcContent},
     dbc_transaction::DbcTransaction,
     error::{Error, Result},
     key_manager::{
         KeyManager, NodeSignature, PublicKey, PublicKeySet, Signature, SimpleKeyManager,
         SimpleSigner,
     },
-    mint::{
-        Mint, MintSignatures, ReissueRequest, ReissueTransaction, SimpleSpendBook, SpendBook,
-        GENESIS_DBC_INPUT,
-    },
+    mint::{Mint, MintSignatures, ReissueRequest, ReissueTransaction, SimpleSpendBook, SpendBook},
 };
 
 impl From<[u8; 32]> for Hash {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,14 +85,12 @@ pub fn bls_dkg_id() -> bls_dkg::outcome::Outcome {
 
     let owner_name = rand::random();
     let threshold = 0;
-    let (mut key_gen, proposal) = match bls_dkg::KeyGen::initialize(
-        owner_name,
-        threshold,
-        BTreeSet::from_iter(vec![owner_name]),
-    ) {
-        Ok(key_gen_init) => key_gen_init,
-        Err(e) => panic!("Failed to init key gen {:?}", e),
-    };
+    let (mut key_gen, proposal) =
+        match bls_dkg::KeyGen::initialize(owner_name, threshold, BTreeSet::from_iter([owner_name]))
+        {
+            Ok(key_gen_init) => key_gen_init,
+            Err(e) => panic!("Failed to init key gen {:?}", e),
+        };
 
     let mut msgs = vec![proposal];
     while let Some(msg) = msgs.pop() {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -996,12 +996,6 @@ mod tests {
         todo!()
     }
 
-    #[quickcheck]
-    #[ignore]
-    fn prop_reject_invalid_prefix() {
-        todo!();
-    }
-
     #[test]
     fn test_inputs_are_validated() -> Result<(), Error> {
         let mint_owner = crate::bls_dkg_id();


### PR DESCRIPTION
This PR adapts DBC's to enforce one-time-keys by using the DBC owner as the spend book key.

__Status:__
- [X] library building
- [X] tests passing
- [ ] update mint REPL